### PR TITLE
README.md: use https for retreat.mirage.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 just a simple MirageOS unikernel serving a markdown document at [https://retreat.mirage.io](https://retreat.mirage.io)
 
-Code and style stolen from @pqwy's [BTC Piñata](http://ownme.ipredator.se) ([code](https://github.com/mirleft/btc-pinata)).
+Code and style stolen from @pqwy's [BTC Piñata](https://github.com/mirleft/btc-pinata).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # marrakech
 
-just a simple MirageOS unikernel serving a markdown document at [http://retreat.mirage.io](http://retreat.mirage.io)
+just a simple MirageOS unikernel serving a markdown document at [https://retreat.mirage.io](https://retreat.mirage.io)
 
 Code and style stolen from @pqwy's [BTC Piñata](http://ownme.ipredator.se) ([code](https://github.com/mirleft/btc-pinata)).


### PR DESCRIPTION
Https has been working for retreat.mirage.io for a while now.

Tangent: the bitcoin piñata is down and the link is dead. I'm not sure if the source is still available somewhere, but if so the link could be changed to that instead.